### PR TITLE
Fix leanrepl closing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Once running, the server exposes a FastAPI application for LeanREPL interaction.
 > [!NOTE]
 > Make sure `mathlib4` and `repl` exist in the workspace directory before launching the server.
 
-The server is up! You can test the endpoint with:
+The server is up! You can test the endpoint with the same cURL request as in the containerized section.
+
+If you change the code, validate your changes by running tests with:
 
 ```sh
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ datasets
 mypy
 types-setuptools
 types-tqdm
+psutil

--- a/server/leanrepl.py
+++ b/server/leanrepl.py
@@ -157,8 +157,8 @@ class LeanREPL:
         Terminate the REPL process and all its child processes.
         """
         try:
-            # Terminate the entire process group
-            os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+            # stop input to repl (which will result in the program loop for lean repl terminating)
+            self.process.stdin.close()
         except ProcessLookupError:
             # Process already terminated
             pass

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -1,7 +1,11 @@
 import os
 import textwrap
+import time
 import uuid
 
+import psutil
+
+from server.leanrepl import LeanREPL
 from utils.proof_utils import has_error_response, parse_client_response
 
 
@@ -140,3 +144,114 @@ class TestLeanServer:
         result = parse_client_response(response["results"][0])
         assert result["is_valid_with_sorry"]
         assert not result["is_valid_no_sorry"]
+
+    def test_repl_close_graceful_termination(self):
+        """Test that calling close() on a LeanREPL instance terminates the process gracefully."""
+        # Create a new REPL instance
+        repl = LeanREPL()
+
+        # Get the process ID
+        pid = repl.process.pid
+
+        # Verify the process is running
+        assert repl.process.poll() is None
+        assert psutil.pid_exists(pid)
+
+        # Create child processes tracker
+        parent = psutil.Process(pid)
+        children_before = parent.children(recursive=True)
+        child_pids = [p.pid for p in children_before]
+
+        # Execute a simple command to verify the REPL is working
+        response = repl.one_pass_verify(
+            "def f := 2\nexample : f = 2 := rfl", timeout=10
+        )
+        assert "error" not in response or not response["error"]
+
+        # Call the close method
+        repl.close()
+
+        # Give it a moment to terminate
+        start_time = time.time()
+        max_wait_time = 5  # seconds
+
+        # Wait for the process to terminate or timeout
+        while repl.process.poll() is None and time.time() - start_time < max_wait_time:
+            time.sleep(0.1)
+
+        # Verify the process has terminated
+        assert (
+            repl.process.poll() is not None
+        ), "Process did not terminate within timeout"
+
+        # Verify that child processes have also terminated
+        time.sleep(0.5)  # Give child processes time to terminate
+        for child_pid in child_pids:
+            assert not psutil.pid_exists(
+                child_pid
+            ), f"Child process {child_pid} is still running"
+
+        # Verify we can create a new REPL after closing the old one
+        new_repl = LeanREPL()
+        assert new_repl.process.poll() is None
+        new_repl.close()
+
+    def test_repl_close_after_multiple_commands(self):
+        """Test that calling close() works after executing multiple commands."""
+        repl = LeanREPL()
+
+        # Run a series of commands
+        commands = [
+            "def f := 2\nexample : f = 2 := rfl",
+            "theorem simple_add : 2 + 2 = 4 := by simp",
+            "def g (x : Nat) := x + 1\nexample : g 5 = 6 := rfl",
+        ]
+
+        for cmd in commands:
+            response = repl.one_pass_verify(cmd, timeout=10)
+            assert "error" not in response or not response["error"]
+
+        # Now close the REPL
+        repl.close()
+
+        # Verify the process has terminated
+        assert (
+            repl.process.poll() is not None
+        ), "Process did not terminate after close()"
+
+    def test_repl_del_calls_close(self):
+        """Test that deleting a LeanREPL instance calls close() implicitly."""
+        repl = LeanREPL()
+        pid = repl.process.pid
+
+        # Verify the process is running
+        assert psutil.pid_exists(pid)
+
+        # Delete the repl instance
+        del repl
+
+        # Give it a moment to terminate
+        time.sleep(1)
+
+        # Verify the process has terminated
+        assert not psutil.pid_exists(pid), "Process did not terminate after __del__"
+
+    def test_repl_create_close_multiple(self):
+        """Test creating and closing multiple REPL instances in sequence."""
+        for _ in range(3):
+            repl = LeanREPL()
+            pid = repl.process.pid
+
+            # Verify the process is running
+            assert repl.process.poll() is None
+
+            # Run a simple command
+            response = repl.one_pass_verify("def f := 2", timeout=10)
+            assert "error" not in response or not response["error"]
+
+            # Close the REPL
+            repl.close()
+
+            # Verify the process has terminated
+            assert repl.process.poll() is not None
+            assert not psutil.pid_exists(pid)


### PR DESCRIPTION
When closing the kimina-lean-server the lean repl instances often persist. This is due to using `process.kill` instead of closing the stdin. Modified leanrepl to close stdin so that it would trigger leanrepl's termination condition (when the leanrepl reads an empty line it will stop the program loop).