### PR TITLE
feat: gcp monitoring

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,3 +22,6 @@ LEANSERVER_REPL_MEMORY_LIMIT_GB=8
 
 # Max number of consecutive commands that run on REPL before memory check
 LEANSERVER_REPL_MEMORY_CHECK_INTERVAL=10
+
+# GCP project ID for monitoring, if not provided, monitoring will not be enabled
+LEANSERVER_GCP_PROJECT_ID=

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ mypy
 types-setuptools
 types-tqdm
 psutil
+google-cloud-monitoring

--- a/server/config.py
+++ b/server/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     REPL_MEMORY_CHECK_INTERVAL: int | None = Field(None)
     HEALTHCHECK_CPU_USAGE_THRESHOLD: int | None = Field(None)
     HEALTHCHECK_MEMORY_USAGE_THRESHOLD: int | None = Field(None)
+    GCP_PROJECT_ID: str | None = Field(None)
 
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", env_prefix="LEANSERVER_"
@@ -77,6 +78,7 @@ class Settings(BaseSettings):
         if v == "":
             return None
         return v
+
 
 try:
     settings = Settings()

--- a/server/server.py
+++ b/server/server.py
@@ -106,7 +106,8 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
-        send_cached_metrics()
+        if settings.GCP_PROJECT_ID:
+            send_cached_metrics()
         
         # Cancel cache manager task
         for task in relp_cache_tasks:

--- a/utils/gcp_monitoring.py
+++ b/utils/gcp_monitoring.py
@@ -1,0 +1,129 @@
+from google.cloud import monitoring_v3
+from google.protobuf.timestamp_pb2 import Timestamp
+import time
+from collections import defaultdict
+from threading import Lock
+
+import requests
+
+from server.config import settings
+
+from loguru import logger
+
+
+PROJECT_ID = settings.GCP_PROJECT_ID
+
+
+monitoring_client = monitoring_v3.MetricServiceClient()
+project_name = f"projects/{PROJECT_ID}"
+
+RESOURCE_TYPE = "gce_instance"
+RESOURCE_LABELS = {}
+
+if PROJECT_ID:
+    try:
+        metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/"
+        headers = {"Metadata-Flavor": "Google"}
+
+        instance_id = requests.get(f"{metadata_url}id", headers=headers, timeout=2).text
+        zone_full_path = requests.get(
+            f"{metadata_url}zone", headers=headers, timeout=2
+        ).text
+
+        zone = zone_full_path.split("/")[-1]
+
+        RESOURCE_LABELS = {
+            "project_id": PROJECT_ID,
+            "instance_id": instance_id,
+            "zone": zone,
+        }
+
+        logger.info(
+            f"[GCP Monitoring]GCP Compute Engine instance detected: {instance_id} in zone {zone}"
+        )
+
+    except requests.exceptions.RequestException as e:
+        raise e
+
+    logger.info(
+        f"[GCP Monitoring]Finally used resource type: {RESOURCE_TYPE}, label: {RESOURCE_LABELS}"
+    )
+else:
+    logger.info("[GCP Monitoring]GCP project ID is not set, skipping GCP monitoring")
+
+metric_cache = defaultdict(int)
+cache_lock = Lock()
+last_send_time = time.time()
+SEND_INTERVAL = 30
+
+
+def send_cached_metrics():
+    global last_send_time
+    current_time = time.time()
+
+    if current_time - last_send_time >= SEND_INTERVAL:
+        with cache_lock:
+            if metric_cache:
+                for metric_name, metric_value in metric_cache.items():
+                    try:
+                        logger.debug(
+                            f"[GCP Monitoring]Sending cached metric {metric_name}: {metric_value}"
+                        )
+                        send_event_metric(metric_name, metric_value)
+                    except Exception as e:
+                        logger.error(
+                            f"[GCP Monitoring]Error sending cached metric {metric_name}: {e}"
+                        )
+
+                metric_cache.clear()
+                last_send_time = current_time
+
+
+def send_event_metric(
+    metric_name: str, metric_value: int, metric_labels: dict | None = None
+):
+    """
+    Sends a metric data point to Cloud Monitoring indicating that an event occurred.
+
+    Args:
+    metric_name (str): The name of a custom metric, e.g. 'successful_requests_total'.
+    metric_value (int): The value of the event, e.g. '1' for one occurrence.
+    metric_labels (dict, optional): Additional metric labels, e.g. {'endpoint': '/data'}.
+    """
+    try:
+        series = monitoring_v3.TimeSeries()
+        series.metric.type = f"custom.googleapis.com/lean4_server/{metric_name}"
+
+        if metric_labels:
+            for key, value in metric_labels.items():
+                series.metric.labels[key] = str(value)
+
+        series.resource.type = RESOURCE_TYPE
+        for key, value in RESOURCE_LABELS.items():
+            series.resource.labels[key] = str(value)
+
+        now_timestamp = time.time()
+        seconds = int(now_timestamp)
+        nanos = int((now_timestamp - seconds) * 10**9)
+
+        point = monitoring_v3.Point()
+
+        end_time = Timestamp(seconds=seconds, nanos=nanos)
+        start_time = Timestamp(seconds=seconds, nanos=nanos)
+
+        point.interval = monitoring_v3.TimeInterval(
+            end_time=end_time, start_time=start_time
+        )
+
+        point.value.int64_value = metric_value
+
+        series.points.append(point)
+
+        monitoring_client.create_time_series(name=project_name, time_series=[series])
+    except Exception as e:
+        logger.error(f"[GCP Monitoring]Error sending metric {metric_name}: {e}")
+
+
+def record_metric(metric_name: str, metric_value: int = 1):
+    with cache_lock:
+        metric_cache[metric_name] += metric_value

--- a/utils/gcp_monitoring.py
+++ b/utils/gcp_monitoring.py
@@ -54,7 +54,7 @@ else:
 metric_cache = defaultdict(int)
 cache_lock = Lock()
 last_send_time = time.time()
-SEND_INTERVAL = 30
+SEND_INTERVAL = 60
 
 
 def send_cached_metrics():

--- a/utils/gcp_monitoring.py
+++ b/utils/gcp_monitoring.py
@@ -62,21 +62,23 @@ def send_cached_metrics():
     current_time = time.time()
 
     if current_time - last_send_time >= SEND_INTERVAL:
+        metrics_to_send = {}
         with cache_lock:
             if metric_cache:
-                for metric_name, metric_value in metric_cache.items():
-                    try:
-                        logger.debug(
-                            f"[GCP Monitoring]Sending cached metric {metric_name}: {metric_value}"
-                        )
-                        send_event_metric(metric_name, metric_value)
-                    except Exception as e:
-                        logger.error(
-                            f"[GCP Monitoring]Error sending cached metric {metric_name}: {e}"
-                        )
-
+                metrics_to_send = dict(metric_cache)
                 metric_cache.clear()
                 last_send_time = current_time
+        
+        for metric_name, metric_value in metrics_to_send.items():
+            try:
+                logger.debug(
+                    f"[GCP Monitoring]Sending cached metric {metric_name}: {metric_value}"
+                )
+                send_event_metric(metric_name, metric_value)
+            except Exception as e:
+                logger.error(
+                    f"[GCP Monitoring]Error sending cached metric {metric_name}: {e}"
+                )
 
 
 def send_event_metric(

--- a/utils/repl_cache.py
+++ b/utils/repl_cache.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import uuid
 from collections import OrderedDict, deque
 from queue import Queue
@@ -73,6 +74,8 @@ class LRUReplCache:
                         f"Failed to evict header {str([header_key])[:30]} with id {str(id)}, putting it back"
                     )
                     self.global_repl_pool[id] = (header_key, repl)
+                
+                time.sleep(0)
 
     async def destroy(self, header, id, repl):
         """Close a REPL instance and remove it from the cache."""

--- a/utils/repl_cache.py
+++ b/utils/repl_cache.py
@@ -74,8 +74,6 @@ class LRUReplCache:
                         f"Failed to evict header {str([header_key])[:30]} with id {str(id)}, putting it back"
                     )
                     self.global_repl_pool[id] = (header_key, repl)
-                
-                time.sleep(0)
 
     async def destroy(self, header, id, repl):
         """Close a REPL instance and remove it from the cache."""


### PR DESCRIPTION
# Changes
- use Google Monitoring v3 to upload success/failure metrics for each proof run. These metrics will be batched and sent every minute.

# To Test
- Verify that the metrics are uploaded successfully.

Notes
- need to specify `LEANSERVER_GCP_PROJECT_ID` in environment variables to automatically enable the monitoring feature.
- `instance_id` and `zone` will be automatically retrieved at runtime, so you don't need to specify them.


Can view the uploaded metrics in Metrics Explorer. The metric names will be `custom/lean4_server/proof_verification_failed` and `custom/lean4_server/proof_verification_successful`.