### PR TITLE
feat: compare differences between different versions

### DIFF
--- a/compare_version.py
+++ b/compare_version.py
@@ -51,13 +51,11 @@ def increment_line_values(d):
 if __name__ == "__main__":
     ds = datasets.load_dataset("AI-MO/lean-result-test-sample-2k", split="train")
 
-    ds = ds.select(range(100))
-
     timeout = 60
     batch_size = 1
     num_proc = os.cpu_count() or 16
 
-    url = "http://127.0.0.1:12335"
+    url = "http://127.0.0.1:12332"
 
     client = Lean4Client(base_url=url, disable_cache=False)
 


### PR DESCRIPTION
## Changes

- I've added a dataset and code to compare outputs from a new version for any differences.

This dataset consists of the first 2000 samples selected from `Goedel-LM/Lean-workbook-proofs` at commit hash `76ed1b21fea810fd1b4e32e221389c6cd3e99340`, with all timeout results removed.
