### PR TITLE
Fix header link formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Python SDK simplifies interaction with the server's API.
 - [Client](#client)
 - [Contributing](#contributing)
 - [License](#license)
-- [Citation][#citation]
+- [Citation](#citation)
 
 This repository contains the source code for:
 - the Kimina Lean server


### PR DESCRIPTION
Just a small PR to lix a link I noticed was misformatted.