### PR TITLE
fix: exhausted batch + remove datasets import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "kimina-client"
 version = "0.2.0"
 authors = [
-  { name="Kimi Team - Project Numina", email="contact@projectnumina.com" },
+  { name = "Kimi Team - Project Numina"},
+  { email = "contact@projectnumina.com" },
 ]
 description = "Client SDK to interact with Kimina Lean server."
 readme = "README-client.md"

--- a/server/manager.py
+++ b/server/manager.py
@@ -147,6 +147,7 @@ class Manager:
                 self._busy.discard(repl)
 
                 await repl.close()
+                self._cond.notify(1)
                 del repl
                 logger.info(f"Deleted REPL {uuid.hex[:8]}")
                 return

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -297,6 +297,37 @@ async def test_exhausted(client: TestClient) -> None:
 @pytest.mark.parametrize(
     "client",
     [
+        {"max_repls": 1, "max_repl_uses": 3, "init_repls": {}, "database_url": None},
+    ],
+    indirect=True,  # To parametrize fixture
+)
+async def test_exhausted_with_batch(client: TestClient) -> None:
+    payload = CheckRequest(
+        snippets=[
+            Snippet(id="1", code="#check Nat"),
+            Snippet(id="2", code="#check 0"),
+            Snippet(id="3", code="#check 1"),
+            Snippet(id="4", code="#check 2"),
+        ],
+        debug=True,
+    ).model_dump()
+
+    try:
+        resp = client.post("check", json=payload)
+    except Exception as e:
+        logger.info(f"Error during request: {e}")
+        logger.info(resp.status_code)
+        raise
+
+    results = resp.json()["results"]
+    repl_uuids = set(result["diagnostics"]["repl_uuid"] for result in results)
+    assert len(repl_uuids) == 2, "Expected two different REPLs to be used"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "client",
+    [
         {"init_repls": {}, "database_url": None},
     ],
     indirect=True,


### PR DESCRIPTION
With `LEAN_SERVER_MAX_REPL_USES` set to a positive value (not -1), exhausted REPLs don't notify the other waiting snippets in need of a REPL. 

As soon as a VM has all its REPLs exhausted, any incoming request hangs. 

I added a test to cover that use case. 
I also removed the `datasets` dependency from module imports to speed up client import and server launch.