### PR TITLE
fix: close in its own coroutine

### DIFF
--- a/server/repl.py
+++ b/server/repl.py
@@ -357,3 +357,11 @@ class Repl:
                     where={"uuid": str(self.uuid)},
                     data={"status": ReplStatus.STOPPED},  # type: ignore
                 )
+
+
+async def close_verbose(repl: Repl) -> None:
+    uuid = repl.uuid
+    logger.info(f"Closing REPL {uuid.hex[:8]}")
+    await repl.close()
+    del repl
+    logger.info(f"Closed REPL {uuid.hex[:8]}")


### PR DESCRIPTION
While having a lock, I was potentially starting a new REPL / closing one. 
Those operations can hang so we now run them in their own coroutine. 

I also wrapped the acquisition of the lock with the `while True` (other way around is more dangerous). 

I added a test covering the case where `Repl.close()` hangs forever.